### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,6 +8,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
Potential fix for [https://github.com/rokde/laravel-pergament/security/code-scanning/1](https://github.com/rokde/laravel-pergament/security/code-scanning/1)

To fix the problem, explicitly declare a `permissions` block that limits the GITHUB_TOKEN to the least privileges needed. This workflow only checks out the repository, caches dependencies, installs Composer packages, and runs tests; it does not push commits, create releases, or modify issues/PRs. Therefore, `contents: read` at the workflow level is sufficient and safe.

The best minimal fix without changing functionality is to add a top-level `permissions` section right after the `on:` block (e.g., after line 10). This will apply to all jobs in the workflow (currently just `test`) and restrict the token to read-only repository contents. No imports or additional methods are needed, as this is purely a YAML configuration change.

Concretely, in `.github/workflows/tests.yml`, insert:

```yml
permissions:
  contents: read
```

between the existing `on:` block (lines 3–9) and the `concurrency` block (lines 11–13). No other changes are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
