### PR TITLE
Add semantic <search> HTML element to search UI

### DIFF
--- a/resources/views/components/header.blade.php
+++ b/resources/views/components/header.blade.php
@@ -22,18 +22,20 @@
                 @endif
 
                 @if(config('pergament.search.enabled'))
-                    <form action="{{ route('pergament.search') }}" method="GET" class="relative">
-                        <input
-                            type="text"
-                            name="q"
-                            placeholder="Search..."
-                            class="w-52 pl-3 pr-16 py-1.5 text-sm rounded-lg border border-gray-300 dark:border-gray-600 bg-gray-50 dark:bg-gray-800 text-gray-900 dark:text-gray-100 placeholder-gray-400 dark:placeholder-gray-500 pergament-input"
-                        >
-                        <div class="absolute right-2 top-1/2 -translate-y-1/2 flex items-center gap-0.5 pointer-events-none">
-                            <kbd class="pergament-cmd-esc">⌘</kbd>
-                            <kbd class="pergament-cmd-esc">K</kbd>
-                        </div>
-                    </form>
+                    <search>
+                        <form action="{{ route('pergament.search') }}" method="GET" class="relative">
+                            <input
+                                type="text"
+                                name="q"
+                                placeholder="Search..."
+                                class="w-52 pl-3 pr-16 py-1.5 text-sm rounded-lg border border-gray-300 dark:border-gray-600 bg-gray-50 dark:bg-gray-800 text-gray-900 dark:text-gray-100 placeholder-gray-400 dark:placeholder-gray-500 pergament-input"
+                            >
+                            <div class="absolute right-2 top-1/2 -translate-y-1/2 flex items-center gap-0.5 pointer-events-none">
+                                <kbd class="pergament-cmd-esc">⌘</kbd>
+                                <kbd class="pergament-cmd-esc">K</kbd>
+                            </div>
+                        </form>
+                    </search>
                 @endif
 
                 {{-- Font size controls --}}
@@ -101,14 +103,16 @@
             @endif
 
             @if(config('pergament.search.enabled'))
-                <form action="{{ route('pergament.search') }}" method="GET" class="pt-1">
-                    <input
-                        type="text"
-                        name="q"
-                        placeholder="Search..."
-                        class="w-full pl-3 pr-3 py-1.5 text-sm rounded-lg border border-gray-300 dark:border-gray-600 bg-gray-50 dark:bg-gray-800 text-gray-900 dark:text-gray-100 placeholder-gray-400 dark:placeholder-gray-500 pergament-input"
-                    >
-                </form>
+                <search>
+                    <form action="{{ route('pergament.search') }}" method="GET" class="pt-1">
+                        <input
+                            type="text"
+                            name="q"
+                            placeholder="Search..."
+                            class="w-full pl-3 pr-3 py-1.5 text-sm rounded-lg border border-gray-300 dark:border-gray-600 bg-gray-50 dark:bg-gray-800 text-gray-900 dark:text-gray-100 placeholder-gray-400 dark:placeholder-gray-500 pergament-input"
+                        >
+                    </form>
+                </search>
             @endif
 
             <button
@@ -149,23 +153,25 @@
 
 {{-- Command palette --}}
 @if(config('pergament.search.enabled'))
-<div id="cmd-palette-backdrop" class="pergament-cmd-backdrop" aria-modal="true" role="dialog" aria-label="Search">
-    <div class="pergament-cmd-dialog">
-        <div class="pergament-cmd-input-wrap">
-            <svg class="pergament-cmd-icon size-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"></path></svg>
-            <input
-                id="cmd-palette-input"
-                class="pergament-cmd-input"
-                type="text"
-                placeholder="Search documentation, posts, pages…"
-                autocomplete="off"
-                spellcheck="false"
-                aria-autocomplete="list"
-                aria-controls="cmd-palette-results"
-            >
-            <kbd class="pergament-cmd-esc">Esc</kbd>
+<search>
+    <div id="cmd-palette-backdrop" class="pergament-cmd-backdrop" aria-modal="true" role="dialog" aria-label="Search">
+        <div class="pergament-cmd-dialog">
+            <div class="pergament-cmd-input-wrap">
+                <svg class="pergament-cmd-icon size-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"></path></svg>
+                <input
+                    id="cmd-palette-input"
+                    class="pergament-cmd-input"
+                    type="text"
+                    placeholder="Search documentation, posts, pages…"
+                    autocomplete="off"
+                    spellcheck="false"
+                    aria-autocomplete="list"
+                    aria-controls="cmd-palette-results"
+                >
+                <kbd class="pergament-cmd-esc">Esc</kbd>
+            </div>
+            <div id="cmd-palette-results" class="pergament-cmd-results" role="listbox"></div>
         </div>
-        <div id="cmd-palette-results" class="pergament-cmd-results" role="listbox"></div>
     </div>
-</div>
+</search>
 @endif

--- a/resources/views/search/results.blade.php
+++ b/resources/views/search/results.blade.php
@@ -11,21 +11,23 @@
     </h1>
 
     {{-- Search form --}}
-    <form action="{{ route('pergament.search') }}" method="GET" class="mb-8">
-        <div class="relative">
-            <input
-                type="text"
-                name="q"
-                value="{{ $query }}"
-                placeholder="Search documentation and blog..."
-                class="w-full pl-4 pr-12 py-3 text-base rounded-xl border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 placeholder-gray-400 dark:placeholder-gray-500 pergament-input"
-                autofocus
-            >
-            <button type="submit" class="absolute right-3 top-1/2 -translate-y-1/2 p-1.5 text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 transition-colors">
-                <svg class="size-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"></path></svg>
-            </button>
-        </div>
-    </form>
+    <search>
+        <form action="{{ route('pergament.search') }}" method="GET" class="mb-8">
+            <div class="relative">
+                <input
+                    type="text"
+                    name="q"
+                    value="{{ $query }}"
+                    placeholder="Search documentation and blog..."
+                    class="w-full pl-4 pr-12 py-3 text-base rounded-xl border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 placeholder-gray-400 dark:placeholder-gray-500 pergament-input"
+                    autofocus
+                >
+                <button type="submit" class="absolute right-3 top-1/2 -translate-y-1/2 p-1.5 text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 transition-colors">
+                    <svg class="size-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"></path></svg>
+                </button>
+            </div>
+        </form>
+    </search>
 
     {{-- Results --}}
     @if($query !== '')


### PR DESCRIPTION
## Summary

- Wraps all search-related UI with the semantic `<search>` HTML element for improved accessibility
- Applied to desktop search form, mobile search form, and command palette in the header component
- Applied to the search form on the search results page
- The `<search>` element provides an implicit `search` ARIA landmark role, eliminating the need for `role="search"` attributes

## Test plan

- [x] All 213 existing tests pass
- [ ] Verify search forms render correctly in desktop and mobile views
- [ ] Confirm command palette (⌘K) still functions properly
- [ ] Test with a screen reader to verify the search landmark is announced

🤖 Generated with [Claude Code](https://claude.com/claude-code)