### PR TITLE
fix: remove --parallel from test:ci to prevent Windows file rename race condition

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
            "@test:lint",
            "@test:unit"
         ],
-        "test:ci": "pest --parallel --ci"
+        "test:ci": "pest --ci"
     },
     "require": {
         "php": "^8.4",


### PR DESCRIPTION
- fix: remove --parallel from test:ci to prevent Windows file rename race condition