### PR TITLE
fix: decode HTML entities in TOC headings with ampersand

### DIFF
--- a/src/Services/MarkdownRenderer.php
+++ b/src/Services/MarkdownRenderer.php
@@ -66,7 +66,7 @@ final readonly class MarkdownRenderer
 
         foreach ($matches as $match) {
             $headings[] = new DocHeading(
-                text: strip_tags($match[3]),
+                text: html_entity_decode(strip_tags($match[3]), ENT_QUOTES | ENT_HTML5, 'UTF-8'),
                 slug: $match[2],
                 level: (int) $match[1],
             );
@@ -220,7 +220,8 @@ final readonly class MarkdownRenderer
             '/<h([23])>(.*?)<\/h[23]>/s',
             function (array $matches): string {
                 $level = $matches[1];
-                $text = strip_tags($matches[2]);
+                $text = html_entity_decode(strip_tags($matches[2]), ENT_QUOTES | ENT_HTML5, 'UTF-8');
+                $text = str_replace('&', 'and', $text);
                 $slug = Str::slug($text);
 
                 return '<h'.$level.' id="'.$slug.'">'.$matches[2].'</h'.$level.'>';

--- a/tests/Feature/MarkdownRendererTest.php
+++ b/tests/Feature/MarkdownRendererTest.php
@@ -247,6 +247,23 @@ it('highlights code blocks without a language', function (): void {
     expect($html)->not->toContain('data-language');
 });
 
+it('generates slug with "and" for headings containing ampersand', function (): void {
+    $renderer = resolve(MarkdownRenderer::class);
+    $html = $renderer->toHtml('## Laravel & Vue');
+
+    expect($html)->toContain('id="laravel-and-vue"');
+});
+
+it('extracts heading text with decoded ampersand', function (): void {
+    $renderer = resolve(MarkdownRenderer::class);
+    $html = $renderer->toHtml('## Laravel & Vue');
+    $headings = $renderer->extractHeadings($html);
+
+    expect($headings)->toHaveCount(1);
+    expect($headings[0]->text)->toBe('Laravel & Vue');
+    expect($headings[0]->slug)->toBe('laravel-and-vue');
+});
+
 it('returns empty array when no headings present', function (): void {
     $renderer = resolve(MarkdownRenderer::class);
     $html = '<p>Just a paragraph</p>';


### PR DESCRIPTION
- fix: decode HTML entities in TOC headings with ampersand