### PR TITLE
fix: generate .html urls in static sitemap and canonical tags

### DIFF
--- a/src/Console/Commands/GenerateStaticCommand.php
+++ b/src/Console/Commands/GenerateStaticCommand.php
@@ -303,7 +303,7 @@ final class GenerateStaticCommand extends Command
                     }
 
                     $this->collectLinkErrors($pageData);
-                    $canonicalUrl = UrlGenerator::url($docsPrefix, $chapter->slug, $page->slug);
+                    $canonicalUrl = UrlGenerator::url($docsPrefix, $chapter->slug, $page->slug).'.html';
                     $seo = $seoService->resolve($pageData['meta'], $pageData['title'], $canonicalUrl);
 
                     $html = view('pergament::docs.show', [
@@ -372,7 +372,7 @@ final class GenerateStaticCommand extends Command
                 }
 
                 $this->collectLinkErrors($rendered);
-                $canonicalUrl = UrlGenerator::url($blogPrefix, $post->slug);
+                $canonicalUrl = UrlGenerator::url($blogPrefix, $post->slug).'.html';
                 $seo = $seoService->resolve($rendered['meta'], $rendered['title'], $canonicalUrl);
 
                 $html = view('pergament::blog.show', [
@@ -397,7 +397,7 @@ final class GenerateStaticCommand extends Command
                 $posts = $blogService->getPostsByCategory($category);
                 $categorySlug = Str::slug($category);
                 $categoryTitle = Str::title(str_replace('-', ' ', $categorySlug));
-                $canonicalUrl = UrlGenerator::url($blogPrefix, 'category', $categorySlug);
+                $canonicalUrl = UrlGenerator::url($blogPrefix, 'category', $categorySlug).'.html';
                 $seo = $seoService->resolve([], $categoryTitle, $canonicalUrl);
 
                 $html = view('pergament::blog.category', [
@@ -423,7 +423,7 @@ final class GenerateStaticCommand extends Command
                 $posts = $blogService->getPostsByTag($tag);
                 $tagSlug = Str::slug($tag);
                 $tagTitle = Str::title(str_replace('-', ' ', $tagSlug));
-                $canonicalUrl = UrlGenerator::url($blogPrefix, 'tag', $tagSlug);
+                $canonicalUrl = UrlGenerator::url($blogPrefix, 'tag', $tagSlug).'.html';
                 $seo = $seoService->resolve([], $tagTitle, $canonicalUrl);
 
                 $html = view('pergament::blog.tag', [
@@ -447,7 +447,7 @@ final class GenerateStaticCommand extends Command
         foreach ($blogService->getAuthors() as $author) {
             try {
                 $posts = $blogService->getPostsByAuthor($author->slug());
-                $canonicalUrl = UrlGenerator::url($blogPrefix, 'author', $author->slug());
+                $canonicalUrl = UrlGenerator::url($blogPrefix, 'author', $author->slug()).'.html';
                 $seo = $seoService->resolve([], $author->name, $canonicalUrl);
 
                 $html = view('pergament::blog.author', [
@@ -482,7 +482,7 @@ final class GenerateStaticCommand extends Command
                 }
 
                 $this->collectLinkErrors($page);
-                $canonicalUrl = UrlGenerator::url($slug);
+                $canonicalUrl = UrlGenerator::url($slug).'.html';
                 $seo = $seoService->resolve($page['meta'], $page['title'], $canonicalUrl);
 
                 $html = view('pergament::pages.show', [
@@ -516,7 +516,7 @@ final class GenerateStaticCommand extends Command
     private function generateSitemap(SitemapService $sitemapService, string $outputDir): void
     {
         try {
-            $this->writeFile($outputDir.'/sitemap.xml', $sitemapService->generate());
+            $this->writeFile($outputDir.'/sitemap.xml', $sitemapService->generate(htmlExtension: true));
         } catch (Throwable $e) {
             $this->errors[] = "Sitemap: {$e->getMessage()}";
         }

--- a/src/Services/SitemapService.php
+++ b/src/Services/SitemapService.php
@@ -16,8 +16,13 @@ final readonly class SitemapService
 
     /**
      * Generate a sitemap XML string with all discoverable URLs.
+     *
+     * Pass $htmlExtension = true when generating for a static site where every
+     * content page is written as a .html file (e.g. blog/hello-world.html).
+     * Index/directory URLs (root, blog index) are intentionally left unchanged
+     * because static hosts serve those from index.html automatically.
      */
-    public function generate(): string
+    public function generate(bool $htmlExtension = false): string
     {
         $urls = [];
 
@@ -28,8 +33,9 @@ final readonly class SitemapService
 
             foreach ($this->docs->getChapters() as $chapter) {
                 foreach ($chapter->pages as $page) {
+                    $loc = UrlGenerator::url($docsPrefix, $chapter->slug, $page->slug);
                     $urls[] = [
-                        'loc' => UrlGenerator::url($docsPrefix, $chapter->slug, $page->slug),
+                        'loc' => $htmlExtension ? $loc.'.html' : $loc,
                         'priority' => '0.8',
                     ];
                 }
@@ -41,23 +47,26 @@ final readonly class SitemapService
             $urls[] = ['loc' => UrlGenerator::url($blogPrefix), 'priority' => '0.7'];
 
             foreach ($this->blog->getPosts() as $post) {
+                $loc = UrlGenerator::url($blogPrefix, $post->slug);
                 $urls[] = [
-                    'loc' => UrlGenerator::url($blogPrefix, $post->slug),
+                    'loc' => $htmlExtension ? $loc.'.html' : $loc,
                     'lastmod' => $post->date->toDateString(),
                     'priority' => '0.6',
                 ];
             }
 
             foreach ($this->blog->getCategories() as $category) {
+                $loc = UrlGenerator::url($blogPrefix, 'category', Str::slug($category));
                 $urls[] = [
-                    'loc' => UrlGenerator::url($blogPrefix, 'category', Str::slug($category)),
+                    'loc' => $htmlExtension ? $loc.'.html' : $loc,
                     'priority' => '0.5',
                 ];
             }
 
             foreach ($this->blog->getTags() as $tag) {
+                $loc = UrlGenerator::url($blogPrefix, 'tag', Str::slug($tag));
                 $urls[] = [
-                    'loc' => UrlGenerator::url($blogPrefix, 'tag', Str::slug($tag)),
+                    'loc' => $htmlExtension ? $loc.'.html' : $loc,
                     'priority' => '0.4',
                 ];
             }

--- a/tests/Feature/GenerateStaticCommandTest.php
+++ b/tests/Feature/GenerateStaticCommandTest.php
@@ -223,6 +223,42 @@ it('generates sitemap.xml', function (): void {
     expect(file_get_contents($this->outputDir.'/sitemap.xml'))->toContain('<urlset');
 });
 
+it('generates sitemap.xml with .html urls for static hosting', function (): void {
+    $this->artisan('pergament:generate-static', [
+        'output-dir' => $this->outputDir,
+    ])->assertSuccessful();
+
+    $xml = file_get_contents($this->outputDir.'/sitemap.xml');
+
+    expect($xml)->toContain('hello-world.html')
+        ->and($xml)->toContain('getting-started/introduction.html')
+        ->and($xml)->toContain('/blog/category/general.html');
+});
+
+it('generates doc page with .html canonical url', function (): void {
+    $this->artisan('pergament:generate-static', [
+        'output-dir' => $this->outputDir,
+    ])->assertSuccessful();
+
+    $docsPrefix = config('pergament.docs.url_prefix', 'docs');
+    $html = file_get_contents($this->outputDir.'/'.$docsPrefix.'/getting-started/introduction.html');
+
+    expect($html)->toContain('rel="canonical"')
+        ->and($html)->toContain('/docs/getting-started/introduction.html');
+});
+
+it('generates blog post with .html canonical url', function (): void {
+    $this->artisan('pergament:generate-static', [
+        'output-dir' => $this->outputDir,
+    ])->assertSuccessful();
+
+    $blogPrefix = config('pergament.blog.url_prefix', 'blog');
+    $html = file_get_contents($this->outputDir.'/'.$blogPrefix.'/hello-world.html');
+
+    expect($html)->toContain('rel="canonical"')
+        ->and($html)->toContain('/blog/hello-world.html');
+});
+
 it('generates robots.txt', function (): void {
     $this->artisan('pergament:generate-static', [
         'output-dir' => $this->outputDir,

--- a/tests/Feature/SitemapServiceTest.php
+++ b/tests/Feature/SitemapServiceTest.php
@@ -31,3 +31,25 @@ it('includes doc page urls', function (): void {
     expect($xml)->toContain('/docs/getting-started/configuration');
     expect($xml)->toContain('/docs/advanced/customization');
 });
+
+it('appends .html to content page urls when htmlExtension is true', function (): void {
+    $service = resolve(SitemapService::class);
+    $xml = $service->generate(htmlExtension: true);
+
+    expect($xml)->toContain('/docs/getting-started/introduction.html');
+    expect($xml)->toContain('/docs/getting-started/configuration.html');
+    expect($xml)->toContain('/docs/advanced/customization.html');
+    expect($xml)->toContain('/blog/hello-world.html');
+    expect($xml)->toContain('/blog/category/general.html');
+    expect($xml)->toContain('/blog/tag/');
+});
+
+it('does not append .html to root or blog index urls when htmlExtension is true', function (): void {
+    $service = resolve(SitemapService::class);
+    $xml = $service->generate(htmlExtension: true);
+
+    expect($xml)->toContain('<loc>http://localhost/</loc>');
+    expect($xml)->toContain('<loc>http://localhost/blog</loc>');
+    expect($xml)->not->toContain('http://localhost/.html');
+    expect($xml)->not->toContain('http://localhost/blog.html');
+});


### PR DESCRIPTION
- fix: generate .html urls in static sitemap and canonical tags